### PR TITLE
Fixes issue where small images could not be loaded

### DIFF
--- a/helper/loader.py
+++ b/helper/loader.py
@@ -321,7 +321,7 @@ class DynamicDataSets:
 		height, width = image.shape[0:2]
 
 		load_batch_size = self.batch_image_size * self.scale
-		if height < load_batch_size or width < load_batch_size:
+		if height <= load_batch_size or width <= load_batch_size:
 			return None
 
 		y = random.randrange(height - load_batch_size)


### PR DESCRIPTION
Off by one error, when the image width or height was an exact multiple of scale * batch_image_size, an Error occurred.